### PR TITLE
Fix short-term identification bug, and server restart notification bug

### DIFF
--- a/services/analyze.js
+++ b/services/analyze.js
@@ -27,8 +27,13 @@ const handlePotentialNewRelease = (prev, curr) => {
   return curr
 }
 
-// Odd cases: (New release, with one object being a re-release), (expiration and short term
-// release simultaneously)
+// Analyze previous and curr. If an id only occurs once in the arrays, it potentially is
+// a new release. However, if that one hit was found in the prev array it indicates that
+// that apartment simply was removed - hence no announcement is needed. If the hit is in
+// curr however, there is a new apartment. At this stage it is impossible to differ a
+// short-term release to an ordinary release with some re-releases. Right now (2020-02-01)
+// it is presumed that if the matching subsets are longer than 3, it is a re-release, else
+//it is a short-term. This should however be updated later, as it is not bullet proof.
 const handleBatchChange = (prev, curr) => {
   const idHitsDict = countIdHits(prev, curr)
   let hasOnlySoloHits = true
@@ -43,20 +48,19 @@ const handleBatchChange = (prev, curr) => {
       hasOnlySoloHits = false
     }
   }
-  console.log('----------')
-  console.log(amountOfNewApartments)
-  console.log(hasOnlySoloHits)
-  console.log(curr[2].area)
-  console.log('----------')
 
-  if (!hasOnlySoloHits && amountOfNewApartments < 4) {
+  if (
+    !hasOnlySoloHits &&
+    amountOfNewApartments < 4 &&
+    amountOfNewApartments > 0
+  ) {
     let shortTermAmount = factory.amountOfShortTerms(idHitsDict)
     log.handleNewRelease(prev, curr, shortTermAmount)
     factory.handleNewShortTerms(shortTermAmount, curr)
     return
   }
 
-  factory.handleNewFlush(curr)
+  if (amountOfNewApartments > 0) factory.handleNewFlush(curr)
 }
 
 // If zero apartments are in prev, it usually means that the scraper has restarted the

--- a/services/analyze.js
+++ b/services/analyze.js
@@ -3,7 +3,13 @@ const { updateApartments } = require('../services/refresh')
 const users = require('./users')
 const log = require('../utils/log')
 
-const checkIfNewRelease = (prev, curr) => {
+// The first time updateApartments is called (which in turns calls this function),
+// prev is always empty. Jump out of the loop immediately when this happens.
+const checkIfNewRelease = (prev, curr, doEmail) => {
+  if (!doEmail) {
+    log.serverRestart()
+    return curr
+  }
   const areArraysIdentical = arraysOfObjectsAreSame(prev, curr)
   log.isThisANewRelease(areArraysIdentical, prev, curr)
   if (!areArraysIdentical) {
@@ -12,9 +18,6 @@ const checkIfNewRelease = (prev, curr) => {
   return curr
 }
 
-// TODO: If a subset of prev ended this function handles the drop from (for example)
-// 91 to 89 apartments (where all 89 were in prev) as a new release. Add logic that
-// handles this.
 const handlePotentialNewRelease = (prev, curr) => {
   if (prev.length === 0) {
     handleEmptyPreviousBatch(prev, curr)

--- a/services/analyze.js
+++ b/services/analyze.js
@@ -12,6 +12,9 @@ const checkIfNewRelease = (prev, curr) => {
   return curr
 }
 
+// TODO: If a subset of prev ended this function handles the drop from (for example)
+// 91 to 89 apartments (where all 89 were in prev) as a new release. Add logic that
+// handles this.
 const handlePotentialNewRelease = (prev, curr) => {
   if (prev.length === 0) {
     handleEmptyPreviousBatch(prev, curr)
@@ -19,9 +22,41 @@ const handlePotentialNewRelease = (prev, curr) => {
   if (curr.length === 0) {
     return handleEmptyCurrentBatch(prev, curr)
   } else {
-    handleNewRelease(prev, curr)
+    handleBatchChange(prev, curr)
   }
   return curr
+}
+
+// Odd cases: (New release, with one object being a re-release), (expiration and short term
+// release simultaneously)
+const handleBatchChange = (prev, curr) => {
+  const idHitsDict = countIdHits(prev, curr)
+  let hasOnlySoloHits = true
+  let amountOfNewApartments = 0
+
+  for (let apartment in idHitsDict) {
+    if (idHitsDict[apartment]['hits'] === 1) {
+      if (idHitsDict[apartment]['indexes'][0] >= prev.length) {
+        amountOfNewApartments++
+      }
+    } else {
+      hasOnlySoloHits = false
+    }
+  }
+  console.log('----------')
+  console.log(amountOfNewApartments)
+  console.log(hasOnlySoloHits)
+  console.log(curr[2].area)
+  console.log('----------')
+
+  if (!hasOnlySoloHits && amountOfNewApartments < 4) {
+    let shortTermAmount = factory.amountOfShortTerms(idHitsDict)
+    log.handleNewRelease(prev, curr, shortTermAmount)
+    factory.handleNewShortTerms(shortTermAmount, curr)
+    return
+  }
+
+  factory.handleNewFlush(curr)
 }
 
 // If zero apartments are in prev, it usually means that the scraper has restarted the
@@ -71,20 +106,34 @@ const handleNewFlush = curr => {
 }
 
 // Concatenate the list of previous apartments with the new. Check if any
-// object's id matches. In that case some short term apartment(s) has been released.
-const amountOfShortTerms = (prev, curr) => {
+// object's id matches. In the case that some id's don't match -
+// some short term apartment(s) has been released.
+const amountOfShortTerms = idHitsDict => {
   let amountOfShortTerms = 0
-  occurances = {}
-  prevAndCurr = prev.concat(curr)
-  prevAndCurr.map(obj => {
-    occurances[obj.id] = occurances[obj.id] ? occurances[obj.id] + 1 : 1
-  })
-  for (let attr in occurances) {
-    if (occurances[attr] !== 1) {
+  for (let attr in idHitsDict) {
+    if (idHitsDict[attr]['hits'] === 1) {
       amountOfShortTerms++
     }
   }
   return amountOfShortTerms
+}
+
+// TODO: Write tests. Test that an obj with 1 hit also only have length 1 on indexes
+const countIdHits = (prev, curr) => {
+  prevAndCurr = prev.concat(curr)
+  occurances = {}
+  prevAndCurr.forEach((obj, index) => {
+    if (occurances[obj.id] && occurances[obj.id]['hits']) {
+      occurances[obj.id]['hits'] += 1
+      occurances[obj.id]['indexes'].push(index)
+    } else {
+      occurances[obj.id] = {
+        hits: 1,
+        indexes: [index]
+      }
+    }
+  })
+  return occurances
 }
 
 // Return an array of the short term apartments. This method assumes that the latest
@@ -112,5 +161,7 @@ module.exports = {
   checkIfNewRelease: checkIfNewRelease,
   amountOfShortTerms,
   handlePotentialNewRelease,
+  countIdHits,
+  handleBatchChange,
   factory
 }

--- a/test/service/analyze.test.js
+++ b/test/service/analyze.test.js
@@ -28,7 +28,7 @@ describe('analyze', () => {
   })
 
   describe('handleBatchChange()', () => {
-    it('should call handleNewShortTerms once', async () => {
+    it('should call handleNewShortTerms once', () => {
       const handleNewShortTermsStub = sinon
         .stub(analyze.factory, 'handleNewShortTerms')
         .returns(1)
@@ -36,7 +36,7 @@ describe('analyze', () => {
       handleNewShortTermsStub.callCount.should.equal(1)
     })
 
-    it('should not call handleNewFlush', async () => {
+    it('should not call handleNewFlush, as a short-term was released', () => {
       const handleNewFlushStub = sinon
         .stub(analyze.factory, 'handleNewFlush')
         .returns(1)
@@ -44,12 +44,28 @@ describe('analyze', () => {
       handleNewFlushStub.callCount.should.equal(0)
     })
 
-    it('should call handleNewFlush because of a new release with one re-release', async () => {
+    it('should call handleNewFlush because of a new release with one re-release', () => {
       const handleNewFlushStub = sinon
         .stub(analyze.factory, 'handleNewFlush')
         .returns(1)
       analyze.handleBatchChange(prev, newReleaseWithARerelease)
       handleNewFlushStub.callCount.should.equal(1)
+    })
+
+    it('should not call handleNewFlush because of the one drop-off', () => {
+      const handleNewFlushStub = sinon
+        .stub(analyze.factory, 'handleNewFlush')
+        .returns(1)
+      analyze.handleBatchChange(curr, currWithOneDropoff)
+      handleNewFlushStub.callCount.should.equal(0)
+    })
+
+    it('should not call handleNewShortTerms because of the one drop-off', () => {
+      const handleNewShortTermsStub = sinon
+        .stub(analyze.factory, 'handleNewShortTerms')
+        .returns(1)
+      analyze.handleBatchChange(curr, currWithOneDropoff)
+      handleNewShortTermsStub.callCount.should.equal(0)
     })
   })
 
@@ -131,6 +147,23 @@ const curr = [
   }
 ]
 
+const currWithOneDropoff = [
+  {
+    area: 'Nyponet',
+    floor: '18',
+    adress: '0823-2102-2122',
+    id: '0823-2102-2122',
+    link: 'www.nyponet1.se'
+  },
+  {
+    area: 'Nyponet',
+    floor: '05',
+    adress: '0823-9823-2122',
+    id: '0823-9823-2122',
+    link: 'www.nyponet2.se'
+  }
+]
+
 const newReleaseWithARerelease = [
   {
     area: 'Nyponet',
@@ -143,28 +176,28 @@ const newReleaseWithARerelease = [
     area: 'Nyponet',
     floor: '05',
     adress: '0823-6124-2122',
-    id: '0823-9823-2122',
+    id: '0823-6124-2122',
     link: 'www.nyponet2.se'
   },
   {
     area: 'Jerum',
     floor: '01',
     adress: '0823-0192-2122',
-    id: '0823-1010-2122',
+    id: '0823-0192-2122',
     link: 'www.kungshamra1.se'
   },
   {
     area: 'Kungshamra',
     floor: '01',
     adress: '0823-1234-2122',
-    id: '0823-1010-2122',
+    id: '0823-1234-2122',
     link: 'www.kungshamra1.se'
   },
   {
     area: 'Kungshamra',
     floor: '01',
     adress: '0823-6534-2122',
-    id: '0823-1010-2122',
+    id: '0823-6534-2122',
     link: 'www.kungshamra1.se'
   }
 ]

--- a/test/service/analyze.test.js
+++ b/test/service/analyze.test.js
@@ -13,42 +13,6 @@ describe('analyze', () => {
     sinon.restore()
   })
 
-  const prev = [
-    {
-      area: 'Nyponet',
-      floor: '18',
-      adress: '0823-2102-2122',
-      link: 'www.nyponet1.se'
-    },
-    {
-      area: 'Kungshamra',
-      floor: '01',
-      adress: '0823-1010-2122',
-      link: 'www.kungshamra1.se'
-    }
-  ]
-
-  const curr = [
-    {
-      area: 'Nyponet',
-      floor: '18',
-      adress: '0823-2102-2122',
-      link: 'www.nyponet1.se'
-    },
-    {
-      area: 'Nyponet',
-      floor: '05',
-      adress: '0823-9823-2122',
-      link: 'www.nyponet2.se'
-    },
-    {
-      area: 'Kungshamra',
-      floor: '01',
-      adress: '0823-1010-2122',
-      link: 'www.kungshamra1.se'
-    }
-  ]
-
   describe('checkIfNewRelease()', () => {
     it('should return curr', async () => {
       const result = analyze.checkIfNewRelease(prev, curr)
@@ -60,6 +24,32 @@ describe('analyze', () => {
     it('should return curr', async () => {
       const result = analyze.handlePotentialNewRelease(prev, curr)
       result.should.deepEqual(curr)
+    })
+  })
+
+  describe('handleBatchChange()', () => {
+    it('should call handleNewShortTerms once', async () => {
+      const handleNewShortTermsStub = sinon
+        .stub(analyze.factory, 'handleNewShortTerms')
+        .returns(1)
+      analyze.handleBatchChange(prev, curr)
+      handleNewShortTermsStub.callCount.should.equal(1)
+    })
+
+    it('should not call handleNewFlush', async () => {
+      const handleNewFlushStub = sinon
+        .stub(analyze.factory, 'handleNewFlush')
+        .returns(1)
+      analyze.handleBatchChange(prev, curr)
+      handleNewFlushStub.callCount.should.equal(0)
+    })
+
+    it('should call handleNewFlush because of a new release with one re-release', async () => {
+      const handleNewFlushStub = sinon
+        .stub(analyze.factory, 'handleNewFlush')
+        .returns(1)
+      analyze.handleBatchChange(prev, newReleaseWithARerelease)
+      handleNewFlushStub.callCount.should.equal(1)
     })
   })
 
@@ -93,8 +83,88 @@ describe('analyze', () => {
 
   describe('amountOfShortTerms()', () => {
     it('should return 1', async () => {
-      const result = analyze.amountOfShortTerms(prev, curr)
+      const idHitsDict = analyze.countIdHits(prev, curr)
+      const result = analyze.amountOfShortTerms(idHitsDict)
       result.should.deepEqual(1)
     })
   })
 })
+
+const prev = [
+  {
+    area: 'Nyponet',
+    floor: '18',
+    adress: '0823-2102-2122',
+    id: '0823-2102-2122',
+    link: 'www.nyponet1.se'
+  },
+  {
+    area: 'Kungshamra',
+    floor: '01',
+    adress: '0823-1010-2122',
+    id: '0823-1010-2122',
+    link: 'www.kungshamra1.se'
+  }
+]
+
+const curr = [
+  {
+    area: 'Nyponet',
+    floor: '18',
+    adress: '0823-2102-2122',
+    id: '0823-2102-2122',
+    link: 'www.nyponet1.se'
+  },
+  {
+    area: 'Nyponet',
+    floor: '05',
+    adress: '0823-9823-2122',
+    id: '0823-9823-2122',
+    link: 'www.nyponet2.se'
+  },
+  {
+    area: 'Kungshamra',
+    floor: '01',
+    adress: '0823-1010-2122',
+    id: '0823-1010-2122',
+    link: 'www.kungshamra1.se'
+  }
+]
+
+const newReleaseWithARerelease = [
+  {
+    area: 'Nyponet',
+    floor: '18',
+    adress: '0823-2102-2122',
+    id: '0823-2102-2122',
+    link: 'www.nyponet1.se'
+  },
+  {
+    area: 'Nyponet',
+    floor: '05',
+    adress: '0823-6124-2122',
+    id: '0823-9823-2122',
+    link: 'www.nyponet2.se'
+  },
+  {
+    area: 'Jerum',
+    floor: '01',
+    adress: '0823-0192-2122',
+    id: '0823-1010-2122',
+    link: 'www.kungshamra1.se'
+  },
+  {
+    area: 'Kungshamra',
+    floor: '01',
+    adress: '0823-1234-2122',
+    id: '0823-1010-2122',
+    link: 'www.kungshamra1.se'
+  },
+  {
+    area: 'Kungshamra',
+    floor: '01',
+    adress: '0823-6534-2122',
+    id: '0823-1010-2122',
+    link: 'www.kungshamra1.se'
+  }
+]

--- a/utils/log.js
+++ b/utils/log.js
@@ -13,6 +13,11 @@ const isThisANewRelease = (bool, prev, curr) => {
   console.log(separator)
 }
 
+const serverRestart = () => {
+  if (doNotLog) return
+  console.log('The server seems to have restarted')
+}
+
 const handleEmptyCurrentBatch = (prev, curr) => {
   if (doNotLog) return
   console.log(separator)
@@ -99,5 +104,6 @@ module.exports = {
   handleShortTerms,
   handleNewFlush,
   emailSubscribers,
-  emailAdmins
+  emailAdmins,
+  serverRestart
 }


### PR DESCRIPTION
Short-term identification bug - the short term identification simply didn't work as expected. When a subset of prev was removed (for instance from 91 apartments to 89) the 89 were assessed as short terms. Furthermore, one (or several) re-releases would cause the app to identify all other, ordinary released apartments as short terms.

The comparison approach that is implemented right now can impossibly tell a re-release apart from a short term-release:
[1,2,3] -> [1,2,3,4] (1 new)
[1,2,3] -> [3,4,5,6] (3 new)
The current workaround is to presume that it is a short-term if the "new" amount is 3 >, else assume a re-release and handle it as an ordinary flush.

Furthermore, count the amount of times updateApartments() is called. The first time it is called, it is due to a server restart, hence it is not desired to email all users.